### PR TITLE
[ch30801] Add Actions taken dialog: Previous action text displayed if you reopen the dialog fast after save

### DIFF
--- a/src_ts/elements/pages/action-points/detail/open-add-comments.ts
+++ b/src_ts/elements/pages/action-points/detail/open-add-comments.ts
@@ -68,6 +68,7 @@ export class OpenAddComments extends ErrorHandlerMixin(InputAttrsMixin(LitElemen
 
   open() {
     const dialog = this.shadowRoot!.querySelector<any>('#commentDialog') as EtoolsDialog;
+    this.commentText = '';
     dialog.opened = true;
   }
 


### PR DESCRIPTION
[ch30801] Add Actions taken dialog: Previous action text displayed if you reopen the dialog fast after save