### PR TITLE
[ch33921] Replace `v2/partners` endpoints with `pmp/v3/partners`

### DIFF
--- a/src_ts/endpoints/endpoints.ts
+++ b/src_ts/endpoints/endpoints.ts
@@ -9,7 +9,7 @@ const apdEndpoints = {
     url: '/api/v3/users/changeorganization/'
   },
   partnerOrganisations: {
-    url: '/api/v2/partners/?hidden=false',
+    url: '/api/pmp/v3/partners/?hidden=false',
     exp: 2 * 60 * 60 * 1000, // 2h
     cacheTableName: 'partners'
   },


### PR DESCRIPTION
[ch33921] Replace `v2/partners` endpoints with `pmp/v3/partners`